### PR TITLE
Correct name of OWIN Startup method in quick start docs

### DIFF
--- a/quick-start.rst
+++ b/quick-start.rst
@@ -18,7 +18,7 @@ After installing the package, :doc:`add or update <configuration/owin-bootstrapp
 
 .. code-block:: c#
 
-   public void Configure(IAppBuilder app)
+   public void Configuration(IAppBuilder app)
    {
        app.UseHangfire(config =>
        {


### PR DESCRIPTION
Following the quick start, I couldn't get this working, until I looked at the OWIN bootstrapper docs and noticed the method name was different.