### PR TITLE
Add line to set JobStorage.Current

### DIFF
--- a/background-processing/processing-jobs-in-windows-service.rst
+++ b/background-processing/processing-jobs-in-windows-service.rst
@@ -37,6 +37,7 @@ After installing packages, all you need is to create a new *Hangfire Server* ins
                InitializeComponent();
 
                var storage = new SqlServerStorage("connection_string");
+               JobStorage.Current = storage;
                var options = new BackgroundJobServerOptions();
 
                _server = new BackgroundJobServer(options, storage);


### PR DESCRIPTION
If JobStorage.Current is not set, an InvalidOperationException is thrown.

InvalidOperationException: JobStorage.Current property value has not been initialized. You must set it before using   Hangfire Client or Server API.