### PR TITLE
Method in OWIN Startup.cs needs to be named Configuration

### DIFF
--- a/tutorials/highlight.rst
+++ b/tutorials/highlight.rst
@@ -516,7 +516,7 @@ After the package installed, add or update the OWIN Startup class with the follo
 
 .. code-block:: c#
 
-   public void Configure(IAppBuilder app)
+   public void Configuration(IAppBuilder app)
    {
        GlobalConfiguration.Configuration.UseSqlServerStorage("HighlighterDb");
 


### PR DESCRIPTION
Without this change I was getting the following error:

> No 'Configuration' method was found in class 'Hangfire.Highlighter.Startup, Hangfire.Highlighter, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'.