### PR TITLE
Added example of setting up HangFire with least privilege in SQL

### DIFF
--- a/configuration/using-sql-server.rst
+++ b/configuration/using-sql-server.rst
@@ -56,6 +56,23 @@ If you want to install objects manually, or integrate it with your existing migr
 
    GlobalConfiguration.Configuration.UseSqlServerStorage("<name or connection string>", options);
 
+You can isolate HangFire database access to just the HangFire schema.  You need to create a separate HangFire user and grant the user access only to the HangFire schema. The HangFire user will only be able to alter the HangFire schema. Below is an example of using a `contained database user <https://msdn.microsoft.com/en-us/library/ff929188.aspx/>`_ for HangFire. The HangFire user has least privileges required but still allows it to upgrade the schema correctly in the future.
+
+.. code-block:: sql
+
+   CREATE USER [HangFire] WITH PASSWORD = 'strong_password_for_hangfire'
+   GO
+   
+   IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE [name] = 'HangFire') EXEC ('CREATE SCHEMA [HangFire]')
+   GO
+   
+   ALTER AUTHORIZATION ON SCHEMA::[HangFire] TO [HangFire]
+   GO
+   
+   GRANT CREATE TABLE TO [HangFire]
+   GO
+
+
 Configuring the Polling Interval
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -73,4 +90,3 @@ Please note that **millisecond-based intervals aren't supported**, you can only 
    GlobalConfiguration.Configuration.UseSqlServerStorage("<name or connection string>", options);
 
 If you want to remove the polling technique, consider using the MSMQ extensions or Redis storage implementation.
-


### PR DESCRIPTION
One of the main reasons people do not want to allow HangFire to auto create / update schema objects is because of the concern that an error in HangFire could screw up their database.  Also, DBAs often do not want to allow applications to alter the database structure.  It would be useful to provide an example on the minimum required permissions to add and isolate HangFire in a database.  