### PR TITLE
Correct URL in docs

### DIFF
--- a/tutorials/highlight.rst
+++ b/tutorials/highlight.rst
@@ -15,7 +15,7 @@ Overview
 
 Consider you are building a code snippet gallery web application like `GitHub Gists <http://gist.github.com>`_, and want to implement the syntax highlighting feature. To improve user experience, you are also want it to work even if a user disabled JavaScript in her browser.
 
-To support this scenario and to reduce the project development time, you chosen to use a web service for syntax highlighting, such as http://pygments.appspot.com or http://www.hilite.me.
+To support this scenario and to reduce the project development time, you chosen to use a web service for syntax highlighting, such as http://pygments.org/ or http://www.hilite.me.
 
 .. note::
 


### PR DESCRIPTION
Pygments changed their URL, updated to point to live page.