### PR TITLE
Fix typo in 'Processing jobs in a web application'

### DIFF
--- a/background-processing/processing-jobs-in-web-app.rst
+++ b/background-processing/processing-jobs-in-web-app.rst
@@ -20,7 +20,7 @@ The basic way (but not the simplest -- see the next section) to start using Hang
 .. admonition:: Dispose the server instance when possible
    :class: note
 
-   In some web application frameworks it may be unclear when to call the ``Dispose`` method. If it is really impossible, you can omit this call as :doc:`described here <processing-background-jobs>` (but you'll loose the *graceful shutdown* feature).
+   In some web application frameworks it may be unclear when to call the ``Dispose`` method. If it is really impossible, you can omit this call as :doc:`described here <processing-background-jobs>` (but you'll lose the *graceful shutdown* feature).
 
 For example, in ASP.NET applications the best place for start/dispose method invocations is the ``global.asax.cs`` file:
 


### PR DESCRIPTION
Changed "loose" to "lose"